### PR TITLE
[bug](governance) restore missing sections

### DIFF
--- a/templates/governance.html
+++ b/templates/governance.html
@@ -63,72 +63,137 @@
     </ul>
   </div>
 </div>
-<div class="row">
-  <div class="col" id="structure">
-  </div>
-</div>
-<div class="row">
-  <div class="col" id="unexpected-situations">
+<div class="col" id="structure">
+  <div class="col" id="structure-header">
     <h3>
-      <a class="back-to-top" href="#overview">⇧</a>
-      Unexpected Situations
+      <a class="back-to-top" href="#governance">⇧</a>
+      Community Structure
     </h3>
     <p>
-        This governance document does not cover every possible situation – many unforeseen circumstances can arise within our community. Instead of detailing each one, we offer the following guidance for handling unknown situations:
+    We aim for minimal structure to run the community, but some structure remains necessary to ensure member safety. We welcome new members to join the Events Team. If you want to propose events, reach out to the <a href="/">Events Team</a>.
+    </p>
+    <p>
+    If any community member faces a conflict with a team member, they should follow our <a href="/conflict-resolution">Conflict Resolution protocol</a>. 
+    </p>
+    <p>
+        We maintain the following positions:
+    </p>
+  </div>
+  <div class="col" id="community-leader">
+    <h4>
+      <a class="back-to-top" href="#governance">⇧</a>
+      Community Leader
+    </h4>
+    <p>
+      The Community Leader heads the organization, but holds limited duties compared to the Events Team. The Community Leader:
     </p>
     <ul>
-        <li>If a situation (conflict, problem) involves the Events Team Lead, the issue should be raised with the Community leader.</li>
-        <li>If the situation does not involve the Events Team Lead (even if it involves the Community Leader), the issue should be raised with the Events Team Lead.</li>
+      <li>Takes ultimate responsibility for the community. If a serious issue arises at an event that requires coordination with law enforcement, the Community Leader contacts law enforcement and serves as the primary point of contact for the Cosy Community.</li>
+      <li>Resolves any conflicts or deadlocks within teams.</li>
+      <li>Leads recruitment for new members or leaders for the community.</li>
     </ul>
   </div>
-</div>
-<div class="row">
-  <div class="col" id="communication">
-    <h3>
-      <a class="back-to-top" href="#overview">⇧</a>
-      Communication
-    </h3>
+  <div class="col" id="events-team-leader">
+    <h4>
+      <a class="back-to-top" href="#governance">⇧</a>
+      Events Team Leader
+    </h4>
     <p>
-        Communication stands as the cornerstone of a healthy community. To ensure ease and openness, we will use the following communication channels:
+      The Events Team plays the most important role in the community, as it manages the majority of community activities. Therefore, the Events Team and its leader hold the majority of the community’s responsibilities. 
     </p>
+    <p>The Events Team leader:</p>
     <ul>
-        <li><b>Welcome Chat</b>: This chat serves as an introduction for newcomers and the public. It answers questions for those not yet admitted to the community.</li>
-        <li><b>Community Chat</b>: This chat serves as the main space for the community. It welcomes all topics as long as members respect the Code of Conduct. We encourage off-topic discussions to help build connections.</li>
-        <li><b>Organizers Chat</b>: This private chat serves only for community organizers to address sensitive issues, such as conflicts between members. We use this channel to resolve situations while protecting privacy for everyone involved.</li>
+      <li>Leads the Events Team and drives consensus around topics facing the team and the community.</li>
+      <li>Recruits new community members when the team needs more help to organize events.</li>
+    </ul>
+  </div>
+  <div class="col" id="events-team-member">
+    <h4>
+      <a class="back-to-top" href="#governance">⇧</a>
+      Events Team Member
+    </h4>
+    <p>Events Team members:</p>
+    <ul>
+        <li>Plan, schedule, coordinate, and host events for the community.</li>
+        <li>Document event planning processes so others can learn how to host events.</li>
+        <li>Participate in the Community Chat and help moderate discussions to maintain a Cosy environment that respects the Code of Conduct.</li>
     </ul>
     <p>
-        We choose Telegram for communication due to its privacy features. While WhatsApp is popular in Barcelona, it requires participants to share phone numbers with everyone in the chat, which compromises privacy. We will consider switching to a different platform if we find a better alternative.
+        Any member of the Events Team can propose new members. The Events Team leader facilitates a discussion to determine if the other team members agree to accept the proposal. The leader should drive the conversation towards consensus on whether to add the new member.
     </p>
     <p>
-      We aim to keep communication channels as simple as possible. Too many channels can overwhelm members and make the community feel inactive. We will expand channels only when a single channel becomes too crowded or when there’s a clear need.
+        If the team agrees, the new member should host their first event with one established team member present to ensure the event runs smoothly. The established team member reports on the event’s outcome, allowing the Events Team to decide whether to accept the new member, hold another event, or reject the proposed member.
     </p>
     <p>
+        The team will organise meetings at least every quarter and any member is welcome to attend or drop in with any ideas or concerns.
+    </p>
+  </div>
+  <div class="col" id="information-team">
+    <h4>
+      <a class="back-to-top" href="#governance">⇧</a>
+      Information Team
+    </h4>
+    <p>
+        The Information Team manages the website, Meetup, Telegram channels, domains, and other digital resources to maintain a strong online presence. While the role will be demanding in the early stages, it will become less intensive once the online presence becomes more established.
+    </p>
   </div>
 </div>
-<div class="row">
-  <div class="col" id="admission">
-    <h3>
-      <a class="back-to-top" href="#overview">⇧</a>
-      Community Admission
-    </h3>
+<div class="col" id="unexpected-situations">
+  <h3>
+    <a class="back-to-top" href="#overview">⇧</a>
+    Unexpected Situations
+  </h3>
+  <p>
+      This governance document does not cover every possible situation – many unforeseen circumstances can arise within our community. Instead of detailing each one, we offer the following guidance for handling unknown situations:
+  </p>
+  <ul>
+      <li>If a situation (conflict, problem) involves the Events Team Lead, the issue should be raised with the Community leader.</li>
+      <li>If the situation does not involve the Events Team Lead (even if it involves the Community Leader), the issue should be raised with the Events Team Lead.</li>
+  </ul>
+</div>
+<div class="col" id="communication">
+  <h3>
+    <a class="back-to-top" href="#overview">⇧</a>
+    Communication
+  </h3>
+  <p>
+      Communication stands as the cornerstone of a healthy community. To ensure ease and openness, we will use the following communication channels:
+  </p>
+  <ul>
+      <li><b>Welcome Chat</b>: This chat serves as an introduction for newcomers and the public. It answers questions for those not yet admitted to the community.</li>
+      <li><b>Community Chat</b>: This chat serves as the main space for the community. It welcomes all topics as long as members respect the Code of Conduct. We encourage off-topic discussions to help build connections.</li>
+      <li><b>Organizers Chat</b>: This private chat serves only for community organizers to address sensitive issues, such as conflicts between members. We use this channel to resolve situations while protecting privacy for everyone involved.</li>
+  </ul>
+  <p>
+      We choose Telegram for communication due to its privacy features. While WhatsApp is popular in Barcelona, it requires participants to share phone numbers with everyone in the chat, which compromises privacy. We will consider switching to a different platform if we find a better alternative.
+  </p>
+  <p>
+    We aim to keep communication channels as simple as possible. Too many channels can overwhelm members and make the community feel inactive. We will expand channels only when a single channel becomes too crowded or when there’s a clear need.
+  </p>
+  <p>
+</div>
+<div class="col" id="admission">
+  <h3>
+    <a class="back-to-top" href="#governance">⇧</a>
+    Community Admission
+  </h3>
 
-    <p>
-    We emphasize the importance of members understanding the <a href="/code-of-conduct">Code of Conduct</a>. When a newcomer signs up for the Cosy Polyamory Meetup, we send them a welcome email with questions to ensure they understand the Code of Conduct and the community values. If they answer the questions correctly, we add them to the Meetup group to learn about upcoming events. However, we do not add them to the Community Chat right away.
-    </p>
-    <p>
-        Once the newcomer attends an event without violating the Code of Conduct, we invite them to the Community Chat, making them a full member of the community.
-    </p>
-    <p>
-        Any Events Team member can review a newcomer’s application. If they answer the questions satisfactorily and no concerns arise, the member adds them to the Meetup group. If something seems off, the Events Team discusses how to proceed. After attending an event and following the Code of Conduct, the newcomer receives an invite to the Community Chat.
-    </p>
-    <p>
-        Throughout this process, the Events Team keeps the newcomer informed about their application status, ensuring transparency.
-    </p>
-    </p>
-    If you have any questions, please feel free to <a href="/contact">contact us</a>.
-    </p>
-    <p>
-  </div>
+  <p>
+  We emphasize the importance of members understanding the <a href="/code-of-conduct">Code of Conduct</a>. When a newcomer signs up for the Cosy Polyamory Meetup, we send them a welcome email with questions to ensure they understand the Code of Conduct and the community values. If they answer the questions correctly, we add them to the Meetup group to learn about upcoming events. However, we do not add them to the Community Chat right away.
+  </p>
+  <p>
+      Once the newcomer attends an event without violating the Code of Conduct, we invite them to the Community Chat, making them a full member of the community.
+  </p>
+  <p>
+      Any Events Team member can review a newcomer’s application. If they answer the questions satisfactorily and no concerns arise, the member adds them to the Meetup group. If something seems off, the Events Team discusses how to proceed. After attending an event and following the Code of Conduct, the newcomer receives an invite to the Community Chat.
+  </p>
+  <p>
+      Throughout this process, the Events Team keeps the newcomer informed about their application status, ensuring transparency.
+  </p>
+  </p>
+  If you have any questions, please feel free to <a href="/contact">contact us</a>.
+  </p>
+  <p>
 </div>
 <div class="col" id="back-to-home">
   [ <a href="/">back to home page</a> ] 


### PR DESCRIPTION
while moving paragraphs into divs, ALL of the  Community Structure descriptions (Community Leader, Events Team Leader, Events Team Member, Information Team), got chopped down by mistake

this PR restores the butchered sections

![image](https://github.com/user-attachments/assets/16dcbf3b-4508-4684-b389-48afbf21cda5)




(sorry)

