### PR TITLE
[bug](governance) fix team links

### DIFF
--- a/templates/governance.html
+++ b/templates/governance.html
@@ -70,7 +70,7 @@
       Community Structure
     </h3>
     <p>
-    We aim for minimal structure to run the community, but some structure remains necessary to ensure member safety. We welcome new members to join the Events Team. If you want to propose events, reach out to the <a href="/">Events Team</a>.
+    We aim for minimal structure to run the community, but some structure remains necessary to ensure member safety. We welcome new members to join the Events Team. If you want to propose events, reach out to the <a href="/structure#team">Events Team</a>.
     </p>
     <p>
     If any community member faces a conflict with a team member, they should follow our <a href="/conflict-resolution">Conflict Resolution protocol</a>. 


### PR DESCRIPTION
The most eagle-eyed people will notice that the title is plural, but the fix is singular.

That's because there is another wrong link in in the pdf of the Conflict Resolution, but I don't know which PDF-editing program has been used and I didn't want to clutter the PDF structure re-rendering it.

<img src="https://github.com/user-attachments/assets/2ac60570-192a-4daa-835c-49a00da860f8" width=50% height=50%>