### PR TITLE
[politics](telegram Welcome chat) remove links and mentions

### DIFF
--- a/templates/contact.html
+++ b/templates/contact.html
@@ -13,15 +13,12 @@
           <b>If you are part of our community</b>: if you have been accepted to our Community Chat, please ask your question or leave a comment on that channel. If you would like to reach a specific team member, see our list of Telegram handles for each of our <a href="/structure#team">team members</a>.
         </div>
         <div class="col-lg mb-3">
-          <b>If you are not part of our community</b>: please join us in the <a target=”_blank” href="https://t.me/+PiOTBKlLABs5M2Fi">Telegram Welcome Chat</a> [link] and ask your question / leave your comment there.
-        </div>
-        <div class="col-lg mb-3">
           <b>If you cannot use Telegram</b>: you can also send us a message via <a href="https://www.meetup.com/cosy-polyamory-community/">Meetup</a> but we really prefer to communicate via our Telegram chats.
         </div>
     </div>
   </div>
 </div>
-<div class="row mb-3 text-center" id="contact-logos">
+<div class="row mb-3" id="contact-logos">
   <div class="col">
     <a href="https://www.meetup.com/cosy-polyamory-community/">
     <div class="col">
@@ -32,19 +29,9 @@
     </div>
     </a>
   </div>
-  <div class="col">
-    <a target=”_blank” href="https://t.me/+zHxhD4z5R31hYThi">
-      <div class="col">
-        <img src="/static/img/telegram.svg" style="max-width: 90px" alt="telegram icon">
-      </div>
-      <div class="col">
-        Telegram Welcome Chat
-      </div>
-    </a>
-  </div>
 </div>
 <div class="col" id="back-to-home">
-  [ <a href="/">back to home page</a> ] 
+  [ <a href="/">back to home page</a> ]
 </div>
 
 {% endblock%}

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
           Once approved, you’ll gain access to our Meetup group, where you can RSVP to events and meet members. After attending an event, the organizer may invite you to join our main Telegram Community Chat. Meeting in person helps us ensure a safe and welcoming environment for all.
       </p>
       <p>
-          If you have questions, please join our <a href="https://t.me/+PiOTBKlLABs5M2Fi">Telegram Welcome Chat</a> to connect with our team, ask about our policies, or learn more about upcoming events.
+      If you have questions, please <a href="/contact">connect with our team</a> to ask about our policies, or learn more about upcoming events.
       </p>
       <p>
           We’re excited to meet you and welcome you to our cosy community!
@@ -50,7 +50,6 @@
       </p>
 
       <ul>
-        <li><a target=”_blank” href="https://t.me/+PiOTBKlLABs5M2Fi">Telegram Welcome Chat</a></li>
         <li><a href="https://www.meetup.com/cosy-polyamory-community/">Meetup page</a></li>
         <li><a href="/code-of-conduct">Our Code of Conduct</a></li>
         <li><a href="/values">Our Community Values</a></li>


### PR DESCRIPTION
as we had a person contacting another member without prior consent, we decided to pull the plug on the Welcome chat
it has also been a bit confusing for members from the get-go, people don't know what's the deal
they enter and it's a bit dead and lame and it gives a bad first impression

some questions have been answered and it was useful to send the location of the beach event for people that joined for the first time

but all in all, we are not sure it really adds value to our group
so, guillotine it is